### PR TITLE
Added type_id impl for TextBuffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ keywords = ["egui", "text_edit", "type_checked"]
 categories = ["gui"]
 
 [dependencies]
-egui = { version = "0.31", default-features = false }
+egui = { version = "0", default-features = false }
 thiserror = "2.0"
 
 [dev-dependencies]
-eframe = "0.31"
+eframe = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ keywords = ["egui", "text_edit", "type_checked"]
 categories = ["gui"]
 
 [dependencies]
-egui = { version = "0", default-features = false }
+egui = { version = "0.32", default-features = false }
 thiserror = "2.0"
 
 [dev-dependencies]
-eframe = "0"
+eframe = "0.32"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ impl<T: FromStr> Default for ValText<T, T::Err> {
     }
 }
 
-impl<T, E> TextBuffer for ValText<T, E> {
+impl<T: 'static, E> TextBuffer for ValText<T, E> {
     fn is_mutable(&self) -> bool {
         true
     }
@@ -185,5 +185,9 @@ impl<T, E> TextBuffer for ValText<T, E> {
     fn delete_char_range(&mut self, char_range: std::ops::Range<usize>) {
         self.text.delete_char_range(char_range);
         self.parsed_val = Some((self.value_parser)(&self.text));
+    }
+
+    fn type_id(&self) -> std::any::TypeId {
+        std::any::TypeId::of::<T>()
     }
 }


### PR DESCRIPTION
Since 0.32, the `TextBuffer` trait now requires a `fn type_id(&self) -> std::any::TypeId`.